### PR TITLE
Added basic model parse_transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,18 @@ Generates code to simplify database records handling.
 Here is a short tutorial:
 
 * Include basic model types:
+
     ```erl
     -module(some_module).
     -include_lib("epgsql_utils/include/epgsql_utils_model.hrl").
     ```
 * Declare parse transform:
+
     ```erl
     -compile({parse_transform, epgsql_utils_model}).
     ```
 * Define or include records which is supposed transformed. Type "key" is reserved for primary keys declarations.  Types are taken from **epgsql_utils_orm** by default. Any other module can be specified explicitly.
+
     ```erl
     -record(example, {
         id::key(pos_integer()),
@@ -27,13 +30,15 @@ Here is a short tutorial:
     }).
     ```
 * Delcare corresponding table for each record which is supposed to be transformed
-  ```erl
-  -export_record_model([
+
+    ```erl
+    -export_record_model([
     {example, [{table, {db_shema, table_name}}]}
-  ]).
-  ```
+    ]).
+    ```
 * Declare **pack/2** and **unpack/2** functions. Make sure that all the custom types can be processed too.
-  ```erl
+
+    ```erl
     pack(example, V) ->
         Result = some_packing_function();
     pack(T, V) ->
@@ -43,9 +48,10 @@ Here is a short tutorial:
         Result = some_unpacking_function();
     unpack(T, V) ->
         unpack_record(T, V).
-  ```
+    ```
 
 * Fin. The records will be parsed and can be used with **epgsql_utils_orm**:
+
     ```erl
         epgsql_utils_orm:get_by_cond({some_module, example}, [])
     ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,51 @@
+Epgsql utils
+============
+
+A collection of tools and helpers built around epgsql.
+
+Epgsql utils model
+------------------
+Generates code to simplify database records handling.
+
+Here is a short tutorial:
+
+* Include basic model types:
+    ```erl
+    -module(some_module).
+    -include_lib("epgsql_utils/include/epgsql_utils_model.hrl").
+    ```
+* Declare parse transform:
+    ```erl
+    -compile({parse_transform, epgsql_utils_model}).
+    ```
+* Define or include records which is supposed transformed. Type "key" is reserved for primary keys declarations.  Types are taken from **epgsql_utils_orm** by default. Any other module can be specified explicitly.
+    ```erl
+    -record(example, {
+        id::key(pos_integer()),
+        name::string(),
+        info::some_module:info()
+    }).
+    ```
+* Delcare corresponding table for each record which is supposed to be transformed
+  ```erl
+  -export_record_model([
+    {example, [{table, {db_shema, table_name}}]}
+  ]).
+  ```
+* Declare **pack/2** and **unpack/2** functions. Make sure that all the custom types can be processed too.
+  ```erl
+    pack(example, V) ->
+        Result = some_packing_function();
+    pack(T, V) ->
+        pack_record(T, V).
+
+    unpack(example, V) ->
+        Result = some_unpacking_function();
+    unpack(T, V) ->
+        unpack_record(T, V).
+  ```
+
+* Fin. The records will be parsed and can be used with **epgsql_utils_orm**:
+    ```erl
+        epgsql_utils_orm:get_by_cond({some_module, example}, [])
+    ```

--- a/include/epgsql_utils_model.hrl
+++ b/include/epgsql_utils_model.hrl
@@ -1,0 +1,8 @@
+-ifndef(_epgsql_utils_model_included).
+-define(_epgsql_utils_model_included, yeah).
+
+-type key(T) :: T.
+-type date() :: calendar:date().
+-type datetime() :: calendar:datetime().
+
+-endif.

--- a/include/epgsql_utils_model.hrl
+++ b/include/epgsql_utils_model.hrl
@@ -4,5 +4,6 @@
 -type key(T) :: T.
 -type date() :: calendar:date().
 -type datetime() :: calendar:datetime().
+-type json  () :: [value()] | object().
 
 -endif.

--- a/src/epgsql_utils_model.erl
+++ b/src/epgsql_utils_model.erl
@@ -217,7 +217,7 @@ compose_fun(Name = pack_record, RecordsInfo, ModuleName) ->
                                 erl_syntax:atom(pack_record),
                                 [
                                     erl_syntax:tuple([
-                                        erl_syntax:atom(get(module_name)),
+                                        erl_syntax:atom(ModuleName),
                                         erl_syntax:atom(RecordName)
                                     ]),
                                     erl_syntax:variable('V')

--- a/src/epgsql_utils_model.erl
+++ b/src/epgsql_utils_model.erl
@@ -1,5 +1,5 @@
 %
-% Basic model parse ms_transform
+% Basic model parse_transform
 
 -module(epgsql_utils_model).
 -export([parse_transform/2]).
@@ -18,8 +18,9 @@ parse_transform(AST, _Options) ->
         AST1 = Body ++ Exports ++ End,
         {Head, Tail} = lists:split(length(AST1) - 1, AST1),
         Head ++ Funcs ++ Tail
-    catch T:E ->
-        error(format_error("Parsing error ~p:~p with stacktrace: ~n~p", [T,E, erlang:get_stacktrace()]))
+    catch _T:E ->
+        io:format("~s~n", [format_error("Parsing error: ~s", [E])]),
+        exit(parsing_error)
     end.
 
 -spec parse_record_fields([tuple()]) -> {[atom()], [{atom(), list()}]}.
@@ -57,7 +58,7 @@ parse_field_type({type,_ ,Type,[]}) ->
 parse_field_type({remote_type, _ ,[{atom, _, M}, {atom, _, F}, []]}) ->
     {{M, F}, []};
 parse_field_type(T) ->
-    error(format_error("Unknown type~p", [T])).
+    error(format_error("Unknown type ~p", [T])).
 
 -spec is_key_type(list()) -> boolean().
 is_key_type(Params) ->

--- a/src/epgsql_utils_model.erl
+++ b/src/epgsql_utils_model.erl
@@ -1,0 +1,362 @@
+%
+% Basic model parse ms_transform
+
+-module(epgsql_utils_model).
+-export([parse_transform/2]).
+
+-spec parse_transform(erl_syntax:syntaxTree(), term()) -> erl_syntax:syntaxTree().
+parse_transform(AST, _Options) ->
+    try
+        {ModuleNameLine, ModuleName} = get_module_name(AST),
+        RecordsMap = get_records_map(AST),
+        RecordsInfo = get_records_info(AST, RecordsMap),
+        FullRecordsInfo = prepare_records_info({RecordsInfo, RecordsMap}),
+
+        Exports = lists:map(fun({Name, Arity}) -> compose_export(Name, Arity) end, [{struct_info, 1}]),
+        Funcs = lists:map(fun(FunName) -> compose_fun(FunName, FullRecordsInfo, ModuleName) end, [struct_info, pack_record, unpack_record]),
+
+        {Body, End} = lists:split(ModuleNameLine + 1, AST),
+        AST1 = Body ++ Exports ++ End,
+        {Head, Tail} = lists:split(length(AST1) - 1, AST1),
+        Head ++ Funcs ++ Tail
+    catch T:E ->
+        error(parsing_error,
+              io_lib:format("Parsing error ~p:~p with stacktrace: ~n~p", [T,E, erlang:get_stacktrace()])
+        )
+    end.
+
+-spec parse_record_fields([tuple()]) -> {[atom()], [{atom(), list()}]}.
+parse_record_fields(RecordFields) ->
+    lists:foldl(fun(F, {Keys, Types})->
+            parse_record_fields_(F, {Keys, Types})
+        end,
+        {[], []},
+        RecordFields
+    ).
+
+-spec parse_record_fields_(term(), {[atom()], [{atom(), list()}]}) -> {[atom()], [{atom(), list()}]}.
+parse_record_fields_({record_field, _ ,{atom, _, FieldName}}, _Acc) ->
+    error({untyped_model_field, FieldName});
+parse_record_fields_({typed_record_field,
+                 {record_field,_ , {atom,_ , FieldName}},
+                 {type, _, union, [{atom, _, undefined}, Data]}}, {Keys, Types}) ->
+    {Type, Params} = parse_field_type(Data) ,
+    Keys1 = case is_key_type(Params) of
+        true ->
+            Keys ++ [FieldName];
+        false ->
+            Keys
+    end,
+    {Keys1, Types ++ [{FieldName, Type}]};
+parse_record_fields_(_, Acc = {_, _}) ->
+    Acc.
+
+-spec parse_field_type(tuple()) -> {{atom(), atom()}, list()}.
+parse_field_type({type,_ ,key, [Type]}) ->
+    {T, _} = parse_field_type(Type),
+    {T, [{key, true}]};
+parse_field_type({type,_ ,Type,[]}) ->
+    {{epgsql_utils_orm, Type}, []};
+parse_field_type({remote_type, _ ,[{atom, _, M}, {atom, _, F}, []]}) ->
+    {{M, F}, []};
+parse_field_type(T) ->
+    error(parse_unknown_type, T).
+
+-spec is_key_type(list()) -> boolean().
+is_key_type(Params) ->
+    proplists:is_defined(key, Params).
+
+-spec get_module_name(nonempty_maybe_improper_list()) -> atom().
+get_module_name([]) ->
+    error(no_module_name);
+get_module_name([{attribute, Line, module, Name}| _]) ->
+    {Line, Name};
+get_module_name([_|T]) ->
+    get_module_name(T).
+
+-spec get_records_map(list()) -> list().
+get_records_map([]) ->
+    error(no_record_map);
+get_records_map([{attribute, _, map_record, Map}| _]) ->
+    Map;
+get_records_map([_|T]) ->
+    get_records_map(T).
+
+-spec get_records_info(erl_syntax:syntaxTree(), list()) -> list().
+get_records_info(AST, RecordsMap) ->
+    RecordsInfo = lists:foldl(fun(H, Acc)->
+            get_records_info_(H, Acc, RecordsMap)
+        end,
+        [],
+        AST
+    ),
+    {LostRecords, _} = lists:unzip(lists:filter(fun({RecordName, _}) ->
+            proplists:get_value(RecordName, RecordsInfo) == undefined
+        end,
+        RecordsMap
+    )),
+    case length(LostRecords) of
+        0 -> RecordsInfo;
+        _ -> error(no_model_declaration, [LostRecords])
+    end.
+
+-spec get_records_info_(tuple(), list(), list()) ->list().
+get_records_info_({attribute, _ ,type, {{record, RecordName}, RecordFields, _}}, Acc, RecordMap) ->
+    Table = proplists:get_value(table, proplists:get_value(RecordName, RecordMap, [])),
+    case Table of
+        %%Not a model record
+        undefined ->
+            Acc;
+        _ ->
+            ParsedInfo = parse_record_fields(RecordFields),
+            Acc ++ [{RecordName, ParsedInfo}]
+    end;
+get_records_info_(_, Acc, _RecordMap) ->
+    Acc.
+
+-spec prepare_records_info({list(), list()}) -> list().
+prepare_records_info({RecordsInfo, RecordsMap}) ->
+    lists:map(fun({RecordName, {Keys, Types}})->
+            Table = proplists:get_value(table, proplists:get_value(RecordName, RecordsMap)),
+            {RecordName, {Keys, Types, Table}}
+        end,
+        RecordsInfo
+    ).
+
+-spec compose_fun(atom(), list(), atom()) -> erl_syntax:syntaxTree().
+compose_fun(Name = struct_info, RecordsInfo, _) ->
+    Clauses = lists:foldl(fun({RecordName, {Keys, Types, Table}}, Acc) ->
+            Acc ++ [
+                erl_syntax:clause(
+                    [erl_syntax:abstract({RecordName, table})],
+                    [],
+                    [
+                        erl_syntax:block_expr([
+                            erl_syntax:abstract(Table)
+                        ])
+                    ]
+                ),
+                erl_syntax:clause(
+                    [erl_syntax:abstract({RecordName, keys})],
+                    [],
+                    [
+                        erl_syntax:block_expr([
+                            erl_syntax:abstract(Keys)
+                        ])
+                    ]
+                ),
+                erl_syntax:clause(
+                    [erl_syntax:abstract({RecordName, fields})],
+                    [],
+                    [
+                        erl_syntax:block_expr([
+                            erl_syntax:abstract(Types)
+                        ])
+                    ]
+                )
+            ]
+        end,
+        [],
+        RecordsInfo
+    ),
+
+    FullClauses = Clauses ++ [erl_syntax:clause(
+        [erl_syntax:variable('T')],
+        [],
+        [
+            erl_syntax:block_expr([
+                erl_syntax:application(
+                    erl_syntax:atom(erlang),
+                    erl_syntax:atom(error),
+                    [
+                        erl_syntax:atom(badarg),
+                        erl_syntax:list([erl_syntax:variable('T')])
+                    ]
+                )
+            ])
+        ]
+    )],
+    erl_syntax:revert(erl_syntax:function(
+        erl_syntax:atom(Name),
+        FullClauses
+    ));
+
+compose_fun(Name = pack_record, RecordsInfo, ModuleName) ->
+    Guards = lists:foldl(fun({RecordName, _}, Acc) ->
+            Acc ++ [[erl_syntax:infix_expr(
+                        erl_syntax:variable('T'),
+                        erl_syntax:operator('=:='),
+                        erl_syntax:atom(RecordName)
+            )]]
+        end,
+        [],
+        RecordsInfo
+    ),
+    Clauses = [
+        erl_syntax:clause(
+            [
+                erl_syntax:tuple([erl_syntax:variable('T'), erl_syntax:variable('F')]),
+                erl_syntax:variable('V')
+            ],
+            Guards,
+            [
+                erl_syntax:block_expr([
+                    erl_syntax:application(
+                        erl_syntax:atom(epgsql_utils_orm),
+                        erl_syntax:atom(pack_record_field),
+                        [
+                            erl_syntax:tuple([
+                                erl_syntax:tuple([
+                                    erl_syntax:atom(ModuleName),
+                                    erl_syntax:variable('T')
+                                ]),
+                                erl_syntax:variable('F')
+                            ]),
+                            erl_syntax:variable('V')
+                        ]
+                    )
+                ])
+            ]
+        ),
+        erl_syntax:clause(
+            [
+                erl_syntax:variable('T'),
+                erl_syntax:variable('V')
+            ],
+            Guards,
+            [
+                erl_syntax:block_expr([
+                    erl_syntax:application(
+                        erl_syntax:atom(epgsql_utils_orm),
+                        erl_syntax:atom(pack_record),
+                        [
+                            erl_syntax:tuple([
+                                erl_syntax:atom(get(module_name)),
+                                erl_syntax:variable('T')
+                            ]),
+                            erl_syntax:variable('V')
+                        ]
+                    )
+                ])
+            ]
+        ),
+        erl_syntax:clause(
+            [
+                erl_syntax:variable('T'),
+                erl_syntax:variable('V')
+            ],
+            [],
+            [
+                erl_syntax:block_expr([
+                    erl_syntax:application(
+                        erl_syntax:atom(erlang),
+                        erl_syntax:atom(error),
+                        [
+                            erl_syntax:atom(badarg),
+                            erl_syntax:list([erl_syntax:variable('T'), erl_syntax:variable('V')])
+                        ]
+                    )
+                ])
+            ]
+        )
+    ],
+    FullClauses = Clauses,
+    erl_syntax:revert(erl_syntax:function(
+        erl_syntax:atom(Name),
+        FullClauses
+    ));
+compose_fun(Name = unpack_record, RecordsInfo, ModuleName) ->
+    Guards = lists:foldl(fun({RecordName, _}, Acc) ->
+            Acc ++ [[erl_syntax:infix_expr(
+                        erl_syntax:variable('T'),
+                        erl_syntax:operator('=:='),
+                        erl_syntax:atom(RecordName)
+            )]]
+        end,
+        [],
+        RecordsInfo
+    ),
+    Clauses = [
+        erl_syntax:clause(
+            [
+                erl_syntax:tuple([erl_syntax:variable('T'), erl_syntax:variable('F')]),
+                erl_syntax:variable('V')
+            ],
+            Guards,
+            [
+                erl_syntax:block_expr([
+                    erl_syntax:application(
+                        erl_syntax:atom(epgsql_utils_orm),
+                        erl_syntax:atom(unpack_record_field),
+                        [
+                            erl_syntax:tuple([
+                                erl_syntax:tuple([
+                                    erl_syntax:atom(ModuleName),
+                                    erl_syntax:variable('T')
+                                ]),
+                                erl_syntax:variable('F')
+                            ]),
+                            erl_syntax:variable('V')
+                        ]
+                    )
+                ])
+            ]
+        ),
+        erl_syntax:clause(
+            [
+                erl_syntax:variable('T'),
+                erl_syntax:variable('V')
+            ],
+            Guards,
+            [
+                erl_syntax:block_expr([
+                    erl_syntax:application(
+                        erl_syntax:atom(epgsql_utils_orm),
+                        erl_syntax:atom(unpack_record),
+                        [
+                            erl_syntax:tuple([
+                                erl_syntax:atom(ModuleName),
+                                erl_syntax:variable('T')
+                            ]),
+                            erl_syntax:variable('V')
+                        ]
+                    )
+                ])
+            ]
+        ),
+        erl_syntax:clause(
+            [
+                erl_syntax:variable('T'),
+                erl_syntax:variable('V')
+            ],
+            [],
+            [
+                erl_syntax:block_expr([
+                    erl_syntax:application(
+                        erl_syntax:atom(erlang),
+                        erl_syntax:atom(error),
+                        [
+                            erl_syntax:atom(badarg),
+                            erl_syntax:list([erl_syntax:variable('T'), erl_syntax:variable('V')])
+                        ]
+                    )
+                ])
+            ]
+        )
+    ],
+    FullClauses = Clauses,
+    erl_syntax:revert(erl_syntax:function(
+        erl_syntax:atom(Name),
+        FullClauses
+    )).
+
+-spec compose_export(atom(), non_neg_integer()) -> erl_syntax:syntaxTree().
+compose_export(Name, Arity) ->
+    erl_syntax:revert(erl_syntax:attribute(
+        erl_syntax:atom(export),
+        [
+            erl_syntax:list([
+                erl_syntax:arity_qualifier(erl_syntax:atom(Name), erl_syntax:integer(Arity))
+            ])
+        ]
+    )).

--- a/src/epgsql_utils_orm.erl
+++ b/src/epgsql_utils_orm.erl
@@ -371,14 +371,14 @@ unpack_(date, Date={_, _, _}) ->
     Date;
 unpack_(json, Json)-> jiffy:decode(Json);
 unpack_(atom, Atom) when is_binary(Atom) -> binary_to_atom(Atom, utf8) ;
-unpack_(pos_integer, PosInteger) when is_integer(PosInteger), PosInteger > 0 -> PosInteger;
-unpack_(neg_integer, NegInteger) when is_integer(NegInteger), NegInteger < 0 -> NegInteger;
-unpack_(non_neg_integer, NonNegInteger) when is_integer(NonNegInteger), NonNegInteger >= 0 -> NonNegInteger;
+unpack_(pos_integer, PosInteger) when PosInteger > 0 -> unpack_(integer, PosInteger);
+unpack_(neg_integer, NegInteger) when NegInteger < 0 -> unpack_(integer, NegInteger);
+unpack_(non_neg_integer, NonNegInteger) when NonNegInteger >= 0 -> unpack_(integer, NonNegInteger);
 unpack_(number, Number) when is_float(Number); is_integer(Number) -> Number;
-unpack_(byte, Byte) when is_integer(Byte), Byte >= 1, Byte =< 255 -> Byte;
-unpack_(char, Char) when is_integer(Char), Char >= 0, Char =< 16#10ffff -> Char;
-unpack_(iodata, IoData) -> binary_to_list(IoData);
-unpack_(iolist, IoList) -> binary_to_list(IoList);
+unpack_(byte, Byte) when Byte >= 0, Byte =< 255 -> unpack_(integer, Byte);
+unpack_(char, Char) when Char >= 0, Char =< 16#10ffff -> unpack_(integer, Char);
+unpack_(iodata, IoData) -> unpack_(binary, IoData);
+unpack_(iolist, IoList) -> [unpack_(binary, IoList)];
 
 unpack_(Type, Data) ->
     error(badarg, [Type, Data]).

--- a/src/epgsql_utils_orm.erl
+++ b/src/epgsql_utils_orm.erl
@@ -208,7 +208,7 @@ get_last_create_id() ->
 %% utils
 make_fields_cond(Fields, Values) when is_list(Values), is_list(Fields) ->
     case length(Fields) =:= length(Values) of
-        false -> 
+        false ->
             error(badarg, [Fields, Values]);
         true  ->
             lists:map(
@@ -249,7 +249,7 @@ make_update_object(Type, Object) ->
 
 make_update_object(Type, Object, Conds) ->
     PackedObject = pack(Type, Object),
-    PackedConds  = pack_conds(Type, Conds), 
+    PackedConds  = pack_conds(Type, Conds),
     epgsql_utils_sql:update(struct_info(table, Type), PackedObject, PackedConds).
 
 make_update_proplist(Type, FieldsValues, Conds) ->
@@ -335,6 +335,15 @@ pack_(term, Term) -> term_to_binary(Term);
 pack_(date, Date={_, _, _}) ->
     Date;
 pack_(json, JsonTerm) -> jiffy:encode(JsonTerm);
+pack_(atom, Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8);
+pack_(pos_integer, PosInteger) when is_integer(PosInteger), PosInteger > 0 -> PosInteger;
+pack_(neg_integer, NegInteger) when is_integer(NegInteger), NegInteger < 0 -> NegInteger;
+pack_(non_neg_integer, NonNegInteger) when is_integer(NonNegInteger), NonNegInteger >= 0 -> NonNegInteger;
+pack_(number, Number) when is_float(Number); is_integer(Number) -> Number;
+pack_(byte, Byte) when is_integer(Byte), Byte >= 1, Byte =< 255 -> Byte;
+pack_(char, Char) when is_integer(Char), Char >= 0, Char =< 16#10ffff -> Char;
+pack_(io_data, IoData) -> list_to_binary(IoData);
+pack_(io_list, IoList) -> list_to_binary(IoList);
 
 pack_(Type, Data) ->
     error(badarg, [Type, Data]).
@@ -361,5 +370,15 @@ unpack_(term, Term) -> binary_to_term(Term);
 unpack_(date, Date={_, _, _}) ->
     Date;
 unpack_(json, Json)-> jiffy:decode(Json);
+unpack_(atom, Atom) when is_binary(Atom) -> binary_to_atom(Atom, utf8) ;
+unpack_(pos_integer, PosInteger) when is_integer(PosInteger), PosInteger > 0 -> PosInteger;
+unpack_(neg_integer, NegInteger) when is_integer(NegInteger), NegInteger < 0 -> NegInteger;
+unpack_(non_neg_integer, NonNegInteger) when is_integer(NonNegInteger), NonNegInteger >= 0 -> NonNegInteger;
+unpack_(number, Number) when is_float(Number); is_integer(Number) -> Number;
+unpack_(byte, Byte) when is_integer(Byte), Byte >= 1, Byte =< 255 -> Byte;
+unpack_(char, Char) when is_integer(Char), Char >= 0, Char =< 16#10ffff -> Char;
+unpack_(io_data, IoData) -> binary_to_list(IoData);
+unpack_(io_list, IoList) -> binary_to_list(IoList);
+
 unpack_(Type, Data) ->
     error(badarg, [Type, Data]).

--- a/src/epgsql_utils_orm.erl
+++ b/src/epgsql_utils_orm.erl
@@ -336,14 +336,14 @@ pack_(date, Date={_, _, _}) ->
     Date;
 pack_(json, JsonTerm) -> jiffy:encode(JsonTerm);
 pack_(atom, Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8);
-pack_(pos_integer, PosInteger) when is_integer(PosInteger), PosInteger > 0 -> PosInteger;
-pack_(neg_integer, NegInteger) when is_integer(NegInteger), NegInteger < 0 -> NegInteger;
-pack_(non_neg_integer, NonNegInteger) when is_integer(NonNegInteger), NonNegInteger >= 0 -> NonNegInteger;
+pack_(pos_integer, PosInteger) when PosInteger > 0 -> pack_(integer, PosInteger);
+pack_(neg_integer, NegInteger) when NegInteger < 0 -> pack_(integer, NegInteger);
+pack_(non_neg_integer, NonNegInteger) when NonNegInteger >= 0 -> pack_(integer, NonNegInteger);
 pack_(number, Number) when is_float(Number); is_integer(Number) -> Number;
-pack_(byte, Byte) when is_integer(Byte), Byte >= 1, Byte =< 255 -> Byte;
-pack_(char, Char) when is_integer(Char), Char >= 0, Char =< 16#10ffff -> Char;
-pack_(io_data, IoData) -> list_to_binary(IoData);
-pack_(io_list, IoList) -> list_to_binary(IoList);
+pack_(byte, Byte) when Byte >= 0, Byte =< 255 -> pack_(integer, Byte);
+pack_(char, Char) when Char >= 0, Char =< 16#10ffff -> pack_(integer, Char);
+pack_(iodata, IoData) -> pack_(binary, IoData);
+pack_(iolist, IoList) -> pack_(binary, IoList);
 
 pack_(Type, Data) ->
     error(badarg, [Type, Data]).
@@ -377,8 +377,8 @@ unpack_(non_neg_integer, NonNegInteger) when is_integer(NonNegInteger), NonNegIn
 unpack_(number, Number) when is_float(Number); is_integer(Number) -> Number;
 unpack_(byte, Byte) when is_integer(Byte), Byte >= 1, Byte =< 255 -> Byte;
 unpack_(char, Char) when is_integer(Char), Char >= 0, Char =< 16#10ffff -> Char;
-unpack_(io_data, IoData) -> binary_to_list(IoData);
-unpack_(io_list, IoList) -> binary_to_list(IoList);
+unpack_(iodata, IoData) -> binary_to_list(IoData);
+unpack_(iolist, IoList) -> binary_to_list(IoList);
 
 unpack_(Type, Data) ->
     error(badarg, [Type, Data]).

--- a/test/epgsql_utils_model_tests.erl
+++ b/test/epgsql_utils_model_tests.erl
@@ -1,0 +1,50 @@
+%%
+%% Static manager tests
+
+-module(epgsql_utils_model_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("epgsql_utils/include/epgsql_utils_model.hrl").
+-compile({parse_transform, epgsql_utils_model}).
+
+-export([pack/2]).
+-export([unpack/2]).
+
+-record(dancer, {
+    id::key(pos_integer()),
+    name::string(),
+    age::non_neg_integer(),
+    hobby::?MODULE:hobby()
+}).
+
+-type hobby() :: {atom(), string()}.
+
+-export_record_model([
+    {dancer, [{table, {test, dancers}}]}
+]).
+
+%%
+pack(hobby, {Type, Value}) ->
+     [atom_to_list(Type), ":", Value];
+pack(T, V) ->
+    pack_record(T, V).
+
+unpack(hobby, V) ->
+    V1 = iolist_to_binary(V),
+    [H1, H2] = binary:split(V1, <<":">>),
+    {binary_to_atom(H1, utf8), H2};
+unpack(T, V) ->
+    unpack_record(T, V).
+%%
+
+struct_info_test() ->
+    ?assertEqual({test, dancers}, ?MODULE:struct_info({dancer, table})),
+    ?assertEqual([id], ?MODULE:struct_info({dancer, keys})),
+    ?assertEqual({epgsql_utils_orm, non_neg_integer},
+                  proplists:get_value(age, ?MODULE:struct_info({dancer, fields}))
+    ).
+
+pack_external_type_test() ->
+    Record = #dancer{id = 42, hobby = {hooker, <<"Tracey">>}},
+    Packed = epgsql_utils_orm:pack({?MODULE, dancer}, Record),
+    ?assertEqual(Record, epgsql_utils_orm:unpack({?MODULE, dancer}, Packed)).

--- a/test/epgsql_utils_model_tests.erl
+++ b/test/epgsql_utils_model_tests.erl
@@ -1,5 +1,5 @@
 %%
-%% Static manager tests
+%% epgsql_utils_model tests
 
 -module(epgsql_utils_model_tests).
 


### PR DESCRIPTION
Basic parse_transform allows to declare types in .hrl files with no need to additionally declare struct_info/1, pack/2, unpack/2 for each type.
Now I'm begging you on my knees: please accept my commit! :pouting_cat:
